### PR TITLE
feat: basic auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ http:
   alerts-path-prefix: /alerts # URL path for the webhook receiver called by an Alertmanager. Defaults to /alerts
   metrics-path: /metrics      # URL path to collect metrics. Defaults to /metrics
   metrics-enabled: true       # Whether to enable metrics or not. Defaults to false
+  basic-password: "secret"    # If set, the alerts endpoint expects basic-auth credentials with username 'alertmanager' and this password
 
 # configuration for the Matrix connection
 matrix:

--- a/internal/config/model.go
+++ b/internal/config/model.go
@@ -29,6 +29,7 @@ type HTTPServer struct {
 	AlertsPathPrefix string `json:"alerts-path-prefix"`
 	MetricsPath      string `json:"metrics-path"`
 	MetricsEnabled   bool   `json:"metrics-enabled"`
+	BasicPassword    string `json:"basic-password"`
 }
 
 func (h *HTTPServer) LogValue() slog.Value {

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 	extractorFunc := handler.CreateRoomExtractor(configuration.HTTPServer.AlertsPathPrefix)
 	slog.InfoContext(ctx, "Room extracting function created")
 
-	http.HandleFunc(configuration.HTTPServer.AlertsPathPrefix, handler.AlertsHandler(ctx, sendingFunc, templatingFunc, extractorFunc))
+	http.HandleFunc(configuration.HTTPServer.AlertsPathPrefix, handler.AlertsHandler(ctx, sendingFunc, templatingFunc, extractorFunc, configuration.HTTPServer.BasicPassword))
 	if configuration.HTTPServer.MetricsEnabled {
 		http.Handle(configuration.HTTPServer.MetricsPath, promhttp.Handler())
 	}


### PR DESCRIPTION
The webhook accepting alerts can now be configured to require basic-auth credentials.