### PR TITLE
chore: bump debian version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o matrix-alertmanager-receiver
 
-FROM gcr.io/distroless/base-debian11
+FROM gcr.io/distroless/base-debian13:latest
 COPY --from=build /app/matrix-alertmanager-receiver /
 USER nonroot:nonroot
 ENTRYPOINT ["/matrix-alertmanager-receiver"]


### PR DESCRIPTION
base-debian11 is a distroless container based on debian11. Debian 11 is end-of-life since 2024-08-31.
Even if it is called distroless, it does contain 2458 files, including some extremely outdated shared libraries (which are not used since matrix-alertmanager-receiver is compiled without CGO) and a ca-certificates.crt, which does not include recent root CAs updates. This file is used by go crypto/tls lib to fill the tls.Config.RootCAs CertPool. This is what bit us.

This PR bumps the debian version so that we all can get the latest ca-certificates.crt file.